### PR TITLE
feature: AMM implementation

### DIFF
--- a/data/amm.go
+++ b/data/amm.go
@@ -1,0 +1,32 @@
+package data
+
+import "fmt"
+
+var txAmmAcceptedMap = map[TransactionType]bool{AMM_DEPOSIT: true, AMM_WITHDRAW: true, AMM_CREATE: true, AMM_VOTE: true, AMM_BID: true, PAYMENT: true}
+
+func (txm *TransactionWithMetaData) AMM() (*AMM, error) {
+	if !txAmmAcceptedMap[txm.GetTransactionType()] {
+		return nil, nil
+	}
+	for _, nodeAffect := range txm.MetaData.AffectedNodes {
+		switch {
+		case nodeAffect.CreatedNode != nil && nodeAffect.CreatedNode.LedgerEntryType == AMMROOT:
+			ammParsed, ok := nodeAffect.CreatedNode.NewFields.(*AMM)
+			if ok {
+				if nodeAffect.CreatedNode.LedgerIndex != nil {
+					ammParsed.LedgerIndex = nodeAffect.CreatedNode.LedgerIndex
+				}
+				return ammParsed, nil
+			}
+		case nodeAffect.ModifiedNode != nil && nodeAffect.ModifiedNode.LedgerEntryType == AMMROOT:
+			ammParsed, ok := nodeAffect.ModifiedNode.FinalFields.(*AMM)
+			if ok {
+				if nodeAffect.ModifiedNode.LedgerIndex != nil {
+					ammParsed.LedgerIndex = nodeAffect.ModifiedNode.LedgerIndex
+				}
+				return ammParsed, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("AMM not found")
+}

--- a/data/balance.go
+++ b/data/balance.go
@@ -32,10 +32,11 @@ type Balance struct {
 	Balance      Value
 	Change       Value
 	Currency     Currency
+	AMMID        *Hash256
 }
 
 func (b Balance) String() string {
-	return fmt.Sprintf("CounterParty: %-34s  Currency: %s Balance: %20s Change: %20s", b.CounterParty, b.Currency, b.Balance, b.Change)
+	return fmt.Sprintf("CounterParty: %-34s  Currency: %s Balance: %20s Change: %20s AMMID: %v", b.CounterParty, b.Currency, b.Balance, b.Change, b.AMMID)
 }
 
 type BalanceSlice []Balance
@@ -53,22 +54,27 @@ func (s BalanceSlice) Less(i, j int) bool {
 	}
 }
 
-func (s *BalanceSlice) Add(counterparty *Account, balance, change *Value, currency *Currency) {
-	*s = append(*s, Balance{*counterparty, *balance, *change, *currency})
+func (s *BalanceSlice) Add(counterparty *Account, balance, change *Value, currency *Currency, AMMID *Hash256) {
+	if change == nil || currency == nil {
+		return
+	}
+	*s = append(*s, Balance{*counterparty, *balance, *change, *currency, AMMID})
 }
 
 type BalanceMap map[Account]*BalanceSlice
 
-func (m *BalanceMap) Add(account *Account, counterparty *Account, balance, change *Value, currency *Currency) {
+func (m *BalanceMap) Add(account *Account, counterparty *Account, balance, change *Value, currency *Currency, AMMID *Hash256) {
 	_, ok := (*m)[*account]
 	if !ok {
 		(*m)[*account] = &BalanceSlice{}
 	}
-	(*m)[*account].Add(counterparty, balance, change, currency)
+	(*m)[*account].Add(counterparty, balance, change, currency, AMMID)
 }
 
+var txBalanceAcceptedMap = map[TransactionType]bool{OFFER_CREATE: true, PAYMENT: true, AMM_DEPOSIT: true, AMM_WITHDRAW: true, AMM_CREATE: true}
+
 func (txm *TransactionWithMetaData) Balances() (BalanceMap, error) {
-	if txm.GetTransactionType() != OFFER_CREATE && txm.GetTransactionType() != PAYMENT {
+	if !txBalanceAcceptedMap[txm.GetTransactionType()] {
 		return nil, nil
 	}
 	balanceMap := BalanceMap{}
@@ -79,19 +85,48 @@ func (txm *TransactionWithMetaData) Balances() (BalanceMap, error) {
 			switch node.CreatedNode.LedgerEntryType {
 			case ACCOUNT_ROOT:
 				created := node.CreatedNode.NewFields.(*AccountRoot)
-				balanceMap.Add(created.Account, &zeroAccount, &zeroNative, created.Balance, &zeroCurrency)
+				balanceMap.Add(created.Account, &zeroAccount, created.Balance, created.Balance, &zeroCurrency, created.AMMID)
 			case RIPPLE_STATE:
 				// New trust line
 				state := node.CreatedNode.NewFields.(*RippleState)
-				balanceMap.Add(&state.LowLimit.Issuer, &state.HighLimit.Issuer, state.Balance.Value, state.Balance.Value, &state.Balance.Currency)
-				balanceMap.Add(&state.HighLimit.Issuer, &state.LowLimit.Issuer, state.Balance.Value.Negate(), state.Balance.Value.Negate(), &state.Balance.Currency)
+				balanceMap.Add(&state.LowLimit.Issuer, &state.HighLimit.Issuer, state.Balance.Value, state.Balance.Value, &state.Balance.Currency, nil)
+				balanceMap.Add(&state.HighLimit.Issuer, &state.LowLimit.Issuer, state.Balance.Value.Negate(), state.Balance.Value.Negate(), &state.Balance.Currency, nil)
+			case AMMROOT:
+				state := node.CreatedNode.NewFields.(*AMM)
+				balanceMap.Add(&state.LPTokenBalance.Issuer,
+					&state.LPTokenBalance.Issuer,
+					state.LPTokenBalance.Value,
+					state.LPTokenBalance.Value,
+					&state.LPTokenBalance.Currency,
+					nil)
+
 			}
 		case node.DeletedNode != nil:
 			switch node.DeletedNode.LedgerEntryType {
 			case RIPPLE_STATE:
-				//?
+				// A deletion (complete termination of a token) can lead to having to use
+				// the deleted node to determine the balance of the counterparty.
+				var previous, current *RippleState
+				if node.DeletedNode.PreviousFields == nil || node.DeletedNode.FinalFields == nil {
+					continue
+				}
+				previous = node.DeletedNode.PreviousFields.(*RippleState)
+				current = node.DeletedNode.FinalFields.(*RippleState)
+
+				if previous.Balance == nil {
+					//flag change
+					continue
+				}
+				change, err := current.Balance.Subtract(previous.Balance)
+				if err != nil {
+					return nil, err
+				}
+				balanceMap.Add(&current.LowLimit.Issuer, &current.HighLimit.Issuer, current.Balance.Value, change.Value, &current.Balance.Currency, nil)
+				balanceMap.Add(&current.HighLimit.Issuer, &current.LowLimit.Issuer, current.Balance.Value.Negate(), change.Value.Negate(), &current.Balance.Currency, nil)
 			case ACCOUNT_ROOT:
 				return nil, fmt.Errorf("Deleted AccountRoot!")
+			case AMMROOT:
+				// 20230911, NvN: Looks like it is not required to handle this case
 			}
 		case node.ModifiedNode != nil:
 			if node.ModifiedNode.PreviousFields == nil {
@@ -121,7 +156,7 @@ func (txm *TransactionWithMetaData) Balances() (BalanceMap, error) {
 					}
 				}
 				if change.num != 0 {
-					balanceMap.Add(current.Account, &zeroAccount, current.Balance, change.Value, &zeroCurrency)
+					balanceMap.Add(current.Account, &zeroAccount, current.Balance, change.Value, &zeroCurrency, current.AMMID)
 				}
 			case RIPPLE_STATE:
 				// Changed non-native balance
@@ -137,8 +172,23 @@ func (txm *TransactionWithMetaData) Balances() (BalanceMap, error) {
 				if err != nil {
 					return nil, err
 				}
-				balanceMap.Add(&current.LowLimit.Issuer, &current.HighLimit.Issuer, current.Balance.Value, change.Value, &current.Balance.Currency)
-				balanceMap.Add(&current.HighLimit.Issuer, &current.LowLimit.Issuer, current.Balance.Value.Negate(), change.Value.Negate(), &current.Balance.Currency)
+				balanceMap.Add(&current.LowLimit.Issuer, &current.HighLimit.Issuer, current.Balance.Value, change.Value, &current.Balance.Currency, nil)
+				balanceMap.Add(&current.HighLimit.Issuer, &current.LowLimit.Issuer, current.Balance.Value.Negate(), change.Value.Negate(), &current.Balance.Currency, nil)
+			case AMMROOT:
+				// Used to retrieve the currency & issuer for lptokens while parsing balances
+				var (
+					previous = node.ModifiedNode.PreviousFields.(*AMM)
+					current  = node.ModifiedNode.FinalFields.(*AMM)
+				)
+				if previous.LPTokenBalance == nil {
+					//Vote change, bid slot change
+					continue
+				}
+				change, err := current.LPTokenBalance.Subtract(previous.LPTokenBalance)
+				if err != nil {
+					return nil, err
+				}
+				balanceMap.Add(&current.LPTokenBalance.Issuer, &current.LPTokenBalance.Issuer, current.LPTokenBalance.Value, change.Value, &current.LPTokenBalance.Currency, nil)
 			}
 		}
 	}

--- a/data/factory.go
+++ b/data/factory.go
@@ -24,6 +24,7 @@ const (
 	NEGATIVE_UNL     LedgerEntryType = 0x4e // 'N'
 	NFTOKEN_PAGE     LedgerEntryType = 0x50 // 'P'
 	NFTOKEN_OFFER    LedgerEntryType = 0x37 // '7'
+	AMMROOT          LedgerEntryType = 0x41 // 'A'
 
 	// TransactionType values come from rippled's "TxFormats.h"
 	PAYMENT              TransactionType = 0
@@ -50,6 +51,11 @@ const (
 	NFTOKEN_CREATE_OFFER TransactionType = 27
 	NFTOKEN_CANCEL_OFFER TransactionType = 28
 	NFTOKEN_ACCEPT_OFFER TransactionType = 29
+	AMM_CREATE           TransactionType = 35
+	AMM_DEPOSIT          TransactionType = 36
+	AMM_WITHDRAW         TransactionType = 37
+	AMM_VOTE             TransactionType = 38
+	AMM_BID              TransactionType = 39
 
 	AMENDMENT  TransactionType = 100
 	SET_FEE    TransactionType = 101
@@ -77,6 +83,7 @@ var LedgerEntryFactory = [...]func() LedgerEntry{
 	NEGATIVE_UNL:     func() LedgerEntry { return &NegativeUNL{leBase: leBase{LedgerEntryType: NEGATIVE_UNL}} },
 	NFTOKEN_PAGE:     func() LedgerEntry { return &NFTokenPage{leBase: leBase{LedgerEntryType: NFTOKEN_PAGE}} },
 	NFTOKEN_OFFER:    func() LedgerEntry { return &NFTokenOffer{leBase: leBase{LedgerEntryType: NFTOKEN_OFFER}} },
+	AMMROOT:          func() LedgerEntry { return &AMM{leBase: leBase{LedgerEntryType: AMMROOT}} },
 }
 
 var TxFactory = [...]func() Transaction{
@@ -107,6 +114,11 @@ var TxFactory = [...]func() Transaction{
 	NFTOKEN_CREATE_OFFER: func() Transaction { return &NFTokenCreateOffer{TxBase: TxBase{TransactionType: NFTOKEN_CREATE_OFFER}} },
 	NFTOKEN_CANCEL_OFFER: func() Transaction { return &NFTCancelOffer{TxBase: TxBase{TransactionType: NFTOKEN_CANCEL_OFFER}} },
 	NFTOKEN_ACCEPT_OFFER: func() Transaction { return &NFTAcceptOffer{TxBase: TxBase{TransactionType: NFTOKEN_ACCEPT_OFFER}} },
+	AMM_CREATE:           func() Transaction { return &AMMCreate{TxBase: TxBase{TransactionType: AMM_CREATE}} },
+	AMM_DEPOSIT:          func() Transaction { return &AMMDeposit{TxBase: TxBase{TransactionType: AMM_DEPOSIT}} },
+	AMM_WITHDRAW:         func() Transaction { return &AMMWithdraw{TxBase: TxBase{TransactionType: AMM_WITHDRAW}} },
+	AMM_VOTE:             func() Transaction { return &AMMVote{TxBase: TxBase{TransactionType: AMM_VOTE}} },
+	AMM_BID:              func() Transaction { return &AMMBid{TxBase: TxBase{TransactionType: AMM_BID}} },
 }
 
 var ledgerEntryNames = [...]string{
@@ -126,6 +138,7 @@ var ledgerEntryNames = [...]string{
 	NEGATIVE_UNL:     "NegativeUNL",
 	NFTOKEN_PAGE:     "NFTokenPage",
 	NFTOKEN_OFFER:    "NFTokenOffer",
+	AMMROOT:          "AMM",
 }
 
 var ledgerEntryTypes = map[string]LedgerEntryType{
@@ -145,6 +158,7 @@ var ledgerEntryTypes = map[string]LedgerEntryType{
 	"NegativeUNL":    NEGATIVE_UNL,
 	"NFTokenPage":    NFTOKEN_PAGE,
 	"NFTokenOffer":   NFTOKEN_OFFER,
+	"AMM":            AMMROOT,
 }
 
 var txNames = [...]string{
@@ -175,6 +189,11 @@ var txNames = [...]string{
 	NFTOKEN_CREATE_OFFER: "NFTokenCreateOffer",
 	NFTOKEN_CANCEL_OFFER: "NFTokenCancelOffer",
 	NFTOKEN_ACCEPT_OFFER: "NFTokenAcceptOffer",
+	AMM_CREATE:           "AMMCreate",
+	AMM_DEPOSIT:          "AMMDeposit",
+	AMM_WITHDRAW:         "AMMWithdraw",
+	AMM_VOTE:             "AMMVote",
+	AMM_BID:              "AMMBid",
 }
 
 var txTypes = map[string]TransactionType{
@@ -205,6 +224,11 @@ var txTypes = map[string]TransactionType{
 	"NFTokenCreateOffer":   NFTOKEN_CREATE_OFFER,
 	"NFTokenCancelOffer":   NFTOKEN_CANCEL_OFFER,
 	"NFTokenAcceptOffer":   NFTOKEN_ACCEPT_OFFER,
+	"AMMCreate":            AMM_CREATE,
+	"AMMDeposit":           AMM_DEPOSIT,
+	"AMMWithdraw":          AMM_WITHDRAW,
+	"AMMVote":              AMM_VOTE,
+	"AMMBid":               AMM_BID,
 }
 
 var HashableTypes []string

--- a/data/ledgerentry.go
+++ b/data/ledgerentry.go
@@ -31,6 +31,7 @@ type AccountRoot struct {
 	NFTokenMinter  *Account         `json:",omitempty"`
 	MintedNFTokens *uint32          `json:",omitempty"`
 	BurnedNFTokens *uint32          `json:",omitempty"`
+	AMMID          *Hash256         `json:",omitempty"`
 }
 
 type RippleState struct {
@@ -219,6 +220,31 @@ type NFTokenOffer struct {
 	Destination      *Account         `json:",omitempty"`
 	Expiration       *uint32          `json:",omitempty"`
 }
+type VoteEntry struct {
+	Account    Account `json:",omitempty"`
+	TradingFee uint32  `json:",omitempty"`
+	VoteWeight uint32  `json:",omitempty"`
+}
+
+type AuctionSlot struct {
+	Account       Account `json:",omitempty"`
+	DiscountedFee uint32  `json:",omitempty"`
+	Expiration    *uint32 `json:",omitempty"`
+	Price         Amount  `json:",omitempty"`
+}
+
+type AMM struct {
+	leBase
+	Flags          *LedgerEntryFlag `json:",omitempty"`
+	Asset          Asset            `json:",omitempty"`
+	Asset2         Asset            `json:",omitempty"`
+	Account        *Account         `json:",omitempty"`
+	LPTokenBalance *Amount          `json:",omitempty"`
+	TradingFee     uint32           `json:",omitempty"`
+	VoteSlots      []VoteEntry      `json:",omitempty"`
+	AuctionSlot    *AuctionSlot     `json:",omitempty"`
+	LedgerIndex    *Hash256         `json:",omitempty"`
+}
 
 func (a *AccountRoot) Affects(account Account) bool {
 	return a.Account != nil && a.Account.Equals(account)
@@ -263,6 +289,8 @@ func (to *NFTokenOffer) Affects(account Account) bool {
 	return (to.Owner != nil && to.Owner.Equals(account)) || (to.Destination != nil && to.Destination.Equals(account))
 }
 
+func (p *AMM) Affects(account Account) bool { return p.Account != nil }
+
 func (le *leBase) GetType() string                     { return ledgerEntryNames[le.LedgerEntryType] }
 func (le *leBase) GetLedgerEntryType() LedgerEntryType { return le.LedgerEntryType }
 func (le *leBase) Prefix() HashPrefix                  { return HP_LEAF_NODE }
@@ -275,4 +303,8 @@ func (le *leBase) GetPreviousTxnId() *Hash256          { return le.PreviousTxnID
 
 func (o *Offer) Ratio() *Value {
 	return o.TakerPays.Ratio(*o.TakerGets)
+}
+
+func (a *AMM) AMMID() *Hash256 {
+	return a.LedgerIndex
 }

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -255,6 +255,53 @@ type NFTAcceptOffer struct {
 	TicketSequence   *uint32  `json:",omitempty"`
 }
 
+type AMMCreate struct {
+	TxBase
+	Amount     Amount `json:",omitempty"`
+	Amount2    Amount `json:",omitempty"`
+	TradingFee uint16 `json:",omitempty"` // Between 0 and 1000 (0 and 1%)
+}
+
+type AMMDeposit struct {
+	TxBase
+	Amount     *Amount `json:",omitempty"`
+	Amount2    *Amount `json:",omitempty"`
+	Asset      Asset   `json:",omitempty"`
+	Asset2     Asset   `json:",omitempty"`
+	EPrice     *Amount `json:",omitempty"`
+	LPTokenOut *Amount `json:",omitempty"`
+}
+
+type AMMWithdraw struct {
+	TxBase
+	Amount    *Amount `json:",omitempty"`
+	Amount2   *Amount `json:",omitempty"`
+	Asset     Asset   `json:",omitempty"`
+	Asset2    Asset   `json:",omitempty"`
+	EPrice    *Amount `json:",omitempty"`
+	LPTokenIn *Amount `json:",omitempty"`
+}
+
+type AMMVote struct {
+	TxBase
+	Asset      Asset  `json:",omitempty"`
+	Asset2     Asset  `json:",omitempty"`
+	TradingFee uint16 `json:",omitempty"` // Between 0 and 1000 (0 and 1%)
+}
+
+type AuthAccounts struct {
+	Account Account `json:",omitempty"`
+}
+
+type AMMBid struct {
+	TxBase
+	Asset        Asset          `json:",omitempty"`
+	Asset2       Asset          `json:",omitempty"`
+	BidMin       *Amount        `json:",omitempty"`
+	BidMax       *Amount        `json:",omitempty"`
+	AuthAccounts []AuthAccounts `json:",omitempty"`
+}
+
 func (t *TxBase) GetBase() *TxBase                    { return t }
 func (t *TxBase) GetType() string                     { return txNames[t.TransactionType] }
 func (t *TxBase) GetTransactionType() TransactionType { return t.TransactionType }


### PR DESCRIPTION
Full AMM implementation.

The AMMID has been added to the account root object as AMMID. Based on this the choice was made to extend the balance functionalities with the AMMID.

The parsing of the balances for the AMM revealed (from my perspective) issues with the balance parsing in the account root where a new account root would have zero balance, while in reality it actually has a balance of X (whatever the initial deposit is).
The balance parsing implementation has been extended to determine the balance using a deleted node: Divesting from an AMM pool leads to having to use the deleted node for determining the balance.

In the AMM (Root) the AMMID is the LedgerIndex, leading to the helper function to get the AMMID in a consistent fashion.